### PR TITLE
Support big endian machines (trie file in BE)

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -1,5 +1,6 @@
 const UnicodeTrie = require('./');
 const pako = require('pako');
+const { swap32BE } = require('./swap');
 
 // Shift size for getting the index-1 table offset.
 const SHIFT_1 = 6 + 5;
@@ -942,6 +943,10 @@ class UnicodeTrieBuilder {
     const trie = this.freeze();
 
     const data = new Uint8Array(trie.data.buffer);
+
+    // swap bytes to big-endian
+    swap32BE(data);
+
     let compressed = pako.deflateRaw(data);
     compressed = pako.deflateRaw(compressed);
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const inflate = require('tiny-inflate');
+const { swap32BE } = require('./swap');
 
 // Shift size for getting the index-1 table offset.
 const SHIFT_1 = 6 + 5;
@@ -85,6 +86,10 @@ class UnicodeTrie {
       // double inflate the actual trie data
       data = inflate(data, new Uint8Array(uncompressedLength));
       data = inflate(data, new Uint8Array(uncompressedLength));
+
+      // swap bytes from big-endian
+      swap32BE(data);
+
       this.data = new Uint32Array(data.buffer);
 
     } else {

--- a/swap.js
+++ b/swap.js
@@ -1,4 +1,6 @@
-const os = require('os');
+const isLittleEndian = () => {
+  return (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x78);
+};
 
 const swap = (b, n, m) => {
   let i = b[n];
@@ -15,7 +17,7 @@ const swap32 = array => {
 };
 
 const swap32BE = array => {
-  if (os.endianness() === 'LE') {
+  if (isLittleEndian()) {
     swap32(array);
   }
 };

--- a/swap.js
+++ b/swap.js
@@ -1,6 +1,4 @@
-const isLittleEndian = () => {
-  return (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x78);
-};
+const isLittleEndian = (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x78);
 
 const swap = (b, n, m) => {
   let i = b[n];
@@ -17,7 +15,7 @@ const swap32 = array => {
 };
 
 const swap32BE = array => {
-  if (isLittleEndian()) {
+  if (isLittleEndian) {
     swap32(array);
   }
 };

--- a/swap.js
+++ b/swap.js
@@ -1,0 +1,25 @@
+const os = require('os');
+
+const swap = (b, n, m) => {
+  let i = b[n];
+  b[n] = b[m];
+  b[m] = i;
+};
+
+const swap32 = array => {
+  const len = array.length;
+  for (let i = 0; i < len; i += 4) {
+    swap(array, i, i + 3);
+    swap(array, i + 1, i + 2);
+  }
+};
+
+const swap32BE = array => {
+  if (os.endianness() === 'LE') {
+    swap32(array);
+  }
+};
+
+module.exports = {
+  swap32BE: swap32BE
+};

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,15 @@ describe('unicode trie', () => {
     assert.equal(trie.get(0x110000), 666);
   });
 
+  it('toBuffer written in big-endian', () => {
+    const trie = new UnicodeTrieBuilder();
+    trie.set(0x4567, 99);
+
+    const buf = trie.toBuffer();
+    const bufferExpected = new Buffer.from([0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 36, 128, 123, 123, 78, 145, 175, 193, 64, 192, 245, 224, 124, 45, 21, 161, 206, 39, 98, 79, 245, 98, 166, 44, 14, 188, 200, 210, 217, 172, 118, 198, 91, 109, 118, 232, 110, 207, 153, 147, 55, 153, 100, 111, 126, 122, 239, 191, 9, 99, 67, 225, 85, 198, 58, 6, 48, 144, 243, 77, 223, 94, 239, 28, 244, 190, 226, 247, 3, 86, 0]);
+    assert.equal(buf.toString('hex'), bufferExpected.toString('hex'));
+  });
+
   it('should work with compressed serialization format', () => {
     const t = new UnicodeTrieBuilder(10, 666);
     t.setRange(13, 6666, 7788, false);


### PR DESCRIPTION
Trie header part is write in big-endian and data part is write in little-endian on Intel x86 and big-endian on MIPS, s390x,... now.

This PR everything unifies and all is write in network byte order (alias big-endian). It does not matter machine endianity.
This is breaking change - content of trie file is different.


Fix for: https://github.com/foliojs/linebreak/issues/8