### PR TITLE
Support big endian machines (trie file in LE)

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -1,5 +1,6 @@
 const UnicodeTrie = require('./');
 const pako = require('pako');
+const { swap32LE } = require('./swap');
 
 // Shift size for getting the index-1 table offset.
 const SHIFT_1 = 6 + 5;
@@ -942,13 +943,17 @@ class UnicodeTrieBuilder {
     const trie = this.freeze();
 
     const data = new Uint8Array(trie.data.buffer);
+
+    // swap bytes to little-endian
+    swap32LE(data);
+
     let compressed = pako.deflateRaw(data);
     compressed = pako.deflateRaw(compressed);
 
     const buf = Buffer.alloc(compressed.length + 12);
-    buf.writeUInt32BE(trie.highStart, 0);
-    buf.writeUInt32BE(trie.errorValue, 4);
-    buf.writeUInt32BE(data.length, 8);
+    buf.writeUInt32LE(trie.highStart, 0);
+    buf.writeUInt32LE(trie.errorValue, 4);
+    buf.writeUInt32LE(data.length, 8);
     for (let i = 0; i < compressed.length; i++) {
       const b = compressed[i];
       buf[i + 12] = b;

--- a/swap.js
+++ b/swap.js
@@ -1,0 +1,27 @@
+const isBigEndian = () => {
+  return (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x12);
+};
+
+const swap = (b, n, m) => {
+  let i = b[n];
+  b[n] = b[m];
+  b[m] = i;
+};
+
+const swap32 = array => {
+  const len = array.length;
+  for (let i = 0; i < len; i += 4) {
+    swap(array, i, i + 3);
+    swap(array, i + 1, i + 2);
+  }
+};
+
+const swap32LE = array => {
+  if (isBigEndian()) {
+    swap32(array);
+  }
+};
+
+module.exports = {
+  swap32LE: swap32LE
+};

--- a/swap.js
+++ b/swap.js
@@ -1,7 +1,5 @@
-const isBigEndian = () => {
-  return (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x12);
-};
 const isBigEndian = (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x12)
+
 const swap = (b, n, m) => {
   let i = b[n];
   b[n] = b[m];
@@ -17,7 +15,7 @@ const swap32 = array => {
 };
 
 const swap32LE = array => {
-  if (isBigEndian()) {
+  if (isBigEndian) {
     swap32(array);
   }
 };

--- a/swap.js
+++ b/swap.js
@@ -1,7 +1,7 @@
 const isBigEndian = () => {
   return (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x12);
 };
-
+const isBigEndian = (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x12)
 const swap = (b, n, m) => {
   let i = b[n];
   b[n] = b[m];

--- a/swap.js
+++ b/swap.js
@@ -1,4 +1,4 @@
-const isBigEndian = (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x12)
+const isBigEndian = (new Uint8Array(new Uint32Array([0x12345678]).buffer)[0] === 0x12);
 
 const swap = (b, n, m) => {
   let i = b[n];

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,15 @@ describe('unicode trie', () => {
     assert.equal(trie.get(0x110000), 666);
   });
 
+  it('toBuffer written in little-endian', () => {
+    const trie = new UnicodeTrieBuilder();
+    trie.set(0x4567, 99);
+
+    const buf = trie.toBuffer();
+    const bufferExpected = new Buffer.from([0, 72, 0, 0, 0, 0, 0, 0, 128, 36, 0, 0, 123, 123, 206, 144, 235, 128, 2, 143, 67, 96, 225, 171, 23, 55, 54, 38, 231, 47, 44, 127, 233, 90, 109, 194, 92, 246, 126, 197, 131, 223, 31, 56, 102, 78, 154, 20, 108, 117, 88, 244, 93, 192, 190, 218, 229, 156, 12, 107, 86, 235, 125, 96, 102, 0, 129, 15, 239, 109, 219, 204, 58, 151, 92, 52, 126, 152, 198, 14, 0]);
+    assert.equal(buf.toString('hex'), bufferExpected.toString('hex'));
+  });
+
   it('should work with compressed serialization format', () => {
     const t = new UnicodeTrieBuilder(10, 666);
     t.setRange(13, 6666, 7788, false);


### PR DESCRIPTION
Same as https://github.com/foliojs/unicode-trie/pull/5, but trie file format is little-endian.